### PR TITLE
Fix feature managers getting registered twice

### DIFF
--- a/TwitchManager.cs
+++ b/TwitchManager.cs
@@ -121,11 +121,6 @@ namespace Twitchmata {
         }
 
         private void DiscoverFeatureManagers() {
-            foreach (var manager in this.GetComponents<FeatureManager>()) {
-                manager.Manager = this;
-                this.ConnectionManager.RegisterFeatureManager(manager);
-            }
-
             foreach (var manager in this.GetComponentsInChildren<FeatureManager>()) {
                 manager.Manager = this;
                 this.ConnectionManager.RegisterFeatureManager(manager);


### PR DESCRIPTION
## Problem
All feature managers are currently registered twice on startup.

This can cause Twitchmata to throw errors about duplicate items, such as trying to create 2 of each managed reward.
```
[TWITCHMATA] Could not create managed reward. Make sure a reward with this name doesn't already exist.
If you wish to convert an existing reward to a managed reward you must first delete the reward in Twitch's dashboard.
```

## Cause
`ConnectionManager.RegisterFeatureManager(FeatureManager manager)` gets called twice for each FeatureManager.

The culprit here is `GetComponents` and `GetComponentsInChildren` being called on the same GameObject right after one another, which returns the same components twice.

Confusingly, `GetComponentsInChildren` returns the components on the children _and also the object itself._

From [the Unity docs](https://docs.unity3d.com/ScriptReference/Component.GetComponentsInChildren.html)
```
Gets references to all components of type T on the same GameObject as the component specified, and any child of the GameObject.
```

## Solution
The solution here is to simply remove the call to `GetComponents` and only use `GetComponentsInChildren`.

I've tested this in my own project and it works fine for me.

If only Unity had named it `GetComponentsInSelfAndChildren`

